### PR TITLE
Fix compilation as C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ ipch/
 *.suo
 *.vcxproj.filters
 *.vcxproj.user
+CMakeCache.txt
+CMakeFiles
+Makefile
+*.cmake
+test_getopt_port
+test_getopt_port_c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ add_executable(test_getopt_port
   testfx.cpp
 )
 
+add_executable(test_getopt_port_c
+  getopt.c
+  main.c
+)
+
 # Have the tests accept const char* -> char* decay-
 target_compile_options(test_getopt_port
   PRIVATE

--- a/getopt.c
+++ b/getopt.c
@@ -31,10 +31,6 @@
 #include <stddef.h>
 #include <string.h>
 
-const int no_argument = 0;
-const int required_argument = 1;
-const int optional_argument = 2;
-
 char* optarg;
 int optopt;
 /* The variable optind [...] shall be initialized to 1 by the system. */

--- a/main.c
+++ b/main.c
@@ -26,34 +26,33 @@
  *
  ******************************************************************************/
 
-#ifndef INCLUDED_GETOPT_PORT_H
-#define INCLUDED_GETOPT_PORT_H
+#include <stddef.h>
+#include <assert.h>
+#include "getopt.h"
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
+/* Just to test if it compiles as C */
 
-#define no_argument 1
-#define required_argument 2
-#define optional_argument 3
-
-extern char* optarg;
-extern int optind, opterr, optopt;
-
-struct option {
-  const char* name;
-  int has_arg;
-  int* flag;
-  int val;
+struct option opts[] = {
+  {"first", no_argument, 0, 'f'},
+  {"second", required_argument, 0, 's'},
+  {"third", optional_argument, 0, 't'},
+  {0, 0, 0, 0}
 };
 
-int getopt(int argc, char* const argv[], const char* optstring);
+int main(int argc, char* argv[]) {
+  int opt;
 
-int getopt_long(int argc, char* const argv[],
-  const char* optstring, const struct option* longopts, int* longindex);
+  while ((opt = getopt_long(argc, argv, "fs:t::", opts, NULL)) != -1) {
+    switch (opt) {
+      case 'f':
+      case 's':
+      case 't':
+        break;
+      default:
+        assert(0);
+        break;
+      }
+  }
 
-#if defined(__cplusplus)
+  return 0;
 }
-#endif
-
-#endif // INCLUDED_GETOPT_PORT_H

--- a/testfx.h
+++ b/testfx.h
@@ -31,7 +31,7 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 #include <iostream>
-#include <string>
+#include <string.h>
 #include <stdexcept>
 #include <stdio.h>
 #include <sstream>


### PR DESCRIPTION
Allows to use getopt_long() in programs written and compiled as C.