### PR TITLE
Make sure exact matches take precedence over abbrevations

### DIFF
--- a/getopt.c
+++ b/getopt.c
@@ -159,6 +159,7 @@ int getopt_long(int argc, char* const argv[], const char* optstring,
   const struct option* match = NULL;
   int num_matches = 0;
   size_t argument_name_length = 0;
+  size_t option_length = 0;
   const char* current_argument = NULL;
   int retval = -1;
 
@@ -175,6 +176,16 @@ int getopt_long(int argc, char* const argv[], const char* optstring,
   current_argument = argv[optind] + 2;
   argument_name_length = strcspn(current_argument, "=");
   for (; o->name; ++o) {
+    /* Check for exact match first. */
+    option_length = strlen(o->name);
+    if (option_length == argument_name_length &&
+        strncmp(o->name, current_argument, option_length) == 0) {
+      match = o;
+      num_matches = 1;
+      break;
+    }
+
+    /* If not exact, count the number of abbreviated matches. */
     if (strncmp(o->name, current_argument, argument_name_length) == 0) {
       match = o;
       ++num_matches;

--- a/getopt_long_tests.cpp
+++ b/getopt_long_tests.cpp
@@ -121,6 +121,23 @@ TEST_F(getopt_fixture, test_getopt_long_ambiguous_abbrev) {
   assert_equal('?', (char)getopt_long(count(argv), argv, "15", opts, NULL));
 }
 
+TEST_F(getopt_fixture, test_getopt_long_ambiguous_exact_match) {
+  // Derived from IWYU bug:
+  // https://github.com/include-what-you-use/include-what-you-use/pull/1260
+  char* argv[] = {"foo.exe", "--error"};
+
+  // If there are multiple options that match arguments by abbreviation, make
+  // sure we accept and prefer exact matches.
+  option opts[] = {
+    {"error", optional_argument, NULL, 'e'},
+    {"error_always", optional_argument, NULL, 'a'},
+    null_opt
+  };
+
+  assert_equal('e', (char)getopt_long(count(argv), argv, "e:a", opts, NULL));
+  assert_equal(-1, (char)getopt_long(count(argv), argv, "e:a", opts, NULL));
+}
+
 TEST_F(getopt_fixture, test_getopt_long_longindex) {
   char* argv[] = {"foo.exe", "--second", "--first"};
 


### PR DESCRIPTION
Consider an options setup with multiple flags with shared prefix, e.g.

    option opts[] = {
      {"error", optional_argument, NULL, 'e'},
      {"error_always", optional_argument, NULL, 'a'},
      null_opt
    };

The '--error' flag used to be unreachable, as the 'error' prefix would match both 'error' and 'error_always', leading to an ambiguous state.

Now consider exact matches separately from abbreviations, so we can use shorter and longer flag names side by side, even if they overlap.